### PR TITLE
Linked table entries to inspect page & contract information vanishes when entered address invalid

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^17.0.1",
     "react-icons": "^4.1.0",
     "react-pro-sidebar": "^0.4.4",
+    "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "rlp-browser": "^1.0.1",

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -3,6 +3,7 @@ import 'react-day-picker/lib/style.css';
 
 import { Table, Icon } from 'semantic-ui-react';
 import moment from 'moment';
+import { Link } from 'react-router-dom';
 
 import AppContext from '../appContext';
 
@@ -17,7 +18,16 @@ const Dashboard = () => {
 
         return tescs.map(({ contractAddress, domain, expiry }) => (
             <Table.Row key={contractAddress}>
-                <Table.Cell>{contractAddress}</Table.Cell>
+                <Table.Cell>
+                    <li>
+                        <Link to={{
+                            pathname: "/tesc/inspect",
+                            state: {
+                                contractAddressFromDashboard: {contractAddress}
+                            }
+                        }}>{contractAddress}</Link>
+                    </li>
+                </Table.Cell>
                 <Table.Cell>{domain}</Table.Cell>
                 <Table.Cell>{moment.unix(parseInt(expiry)).format('DD/MM/YYYY')}</Table.Cell>
                 <Table.Cell textAlign="center">

--- a/src/pages/TescInspect.js
+++ b/src/pages/TescInspect.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { Input, Table, Checkbox } from 'semantic-ui-react';
 
 import BitSet from 'bitset';
@@ -9,7 +9,7 @@ import { FLAG_POSITIONS } from '../utils/tesc';
 import TeSC from '../ethereum/build/contracts/ERCXXXImplementation.json';
 
 
-const TeSCInspect = () => {
+const TeSCInspect = ({ location }) => {
     const { web3 } = useContext(AppContext);
     const [contractAddress, setContractAddress] = useState('');
 
@@ -18,7 +18,23 @@ const TeSCInspect = () => {
     const [signature, setSignature] = useState('');
     const [flags, setFlags] = useState(new BitSet('0'));
 
+    useEffect(() => {
+        if(location.state){
+            const contractAddressFromDashboard = location.state.contractAddressFromDashboard.contractAddress;
+            handleAddressEntered(contractAddressFromDashboard);
+        } 
+    }, []);
+
+    const resetValues = () => {
+        setContractAddress(null);
+        setDomain(null);
+        setExpiry(null);
+        setSignature(null);
+        setFlags(null);
+    }
+
     const handleAddressEntered = async (address) => {
+        resetValues();
         try {
             setContractAddress(address);
             if (address) {


### PR DESCRIPTION
Changes:
- Dashboard: address can be clicked -> go to TescInspect page
- TescInspect: values are reset in the beginning of handleAddressEntered -> information vanishes when entered information becomes invalid

@anhmt90 could you look into that? I'm not sure if I did everything as you intended, since it was my first time using React :)